### PR TITLE
Swap non-HTTPS content

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,8 @@
       <div id="isotope-container"></div>
       <div id="modals"></div>
     </div>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>
+		<script type="text/javascript" src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>
 		<script type="text/javascript" src="js/isotope.js"></script>
     <script type="text/javascript" src="js/konami.js"></script>
 		<script type="text/javascript" src="twitter-bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Problem- by default, [linkedin.github.io](https://linkedin.github.io) loads two scripts (jquery and underscore) from HTTP sources. This results in a mixed content warning in Chrome, shown in the following screenshot: 
<img width="277" alt="screen shot 2015-10-02 at 3 28 58 pm" src="https://cloud.githubusercontent.com/assets/3670674/10259218/9d43b50e-691a-11e5-940e-12603adce86c.png">

The whole site isn't functional without these two scripts, as the main body with tiles and the top navigation bar both depend on them. This pull request modifies their paths to use HTTPS versions, removing the mixed content warning and improving user security.